### PR TITLE
Align with stock statsd plugin, add extra tags, add metric whitelisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ wsgi-file = app.py
 ...
 ```
 
+You can also add additional tags or filter which metrics are published (or how they are published) using one or more optional configuration options:
+
+```ini
+stats-push = dogstatsd:127.0.0.1:8125,myapp
+dogstatsd-extra-tags = app:foo_service,instance:1
+dogstatsd-no-workers = true
+dogstatsd-all_gauges = true
+dogstatsd-whitelist-metric = core.busy_workers
+dogstatsd-whitelist-metric = core.idle_workers
+dogstatsd-whitelist-metric = core.overloaded
+dogstatsd-whitelist-metric = socket.listen_queue
+```
+
 This will begin producing metrics with the prefix defined in the configuration, `myapp` here:
 
 ```console


### PR DESCRIPTION
- After this plugin was created, the stock statsd plugin in the uWSGI repo was updated to support disabling worker metrics and forcing all metrics to be gauges. The first change this commit makes is to port those two changes into this plugin.
- We only use 3-4 metrics of the dozens that uWSGI records. I've added a whitelisting feature that enables us to filter out undesired metrics, reducing our use of Datadog custom metrics.
- We need the ability to specify additional tags, so that we can more easily graph uWSGI metrics belonging to specific applications (or group uWSGI metrics by application). I've added that capability here.

This change is completely backwards compatible. If a user has a config such as the following, the plugin behavior will continue in the exact same manner as before this change:

```
stats-push=dogstatsd:localhost:8135,uwsgi
```

Now, however, we can add more advanced configuration options, like below, to alter the plugin behavior:

```
stats-push=dogstatsd:localhost:8135,uwsgi
dogstatsd-extra-tags=app:foo_service
dogstatsd-no-workers=true
dogstatsd-whitelist-metric=core.busy_workers
dogstatsd-whitelist-metric=core.idle_workers
dogstatsd-whitelist-metric=core.overloaded
dogstatsd-whitelist-metric=socket.listen_queue
```

(Since https://github.com/DataDog/uwsgi-dogstatsd/pull/17 is never going to be merged, it appears.)